### PR TITLE
Improve README and add default API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,45 @@
 
 ## Bundestag API GUI
 
-This repository provides a small Python application with a graphical user interface to query the Bundestag DIP API.
+This repository provides a small Python application with a graphical user interface to query the public Bundestag DIP API.
 
-### Requirements
-- Python 3 with the `requests` library.
-- A valid API key for `https://search.dip.bundestag.de/api/v1`.
+### Installation (Linux)
+
+Below is a step-by-step guide using a Python virtual environment. The commands can be copied directly into a terminal on most Debian/Ubuntu based distributions.
+
+1. **Install dependencies** (Python, `venv` module and git):
+
+   ```bash
+   sudo apt update
+   sudo apt install python3 python3-venv git -y
+   ```
+
+2. **Download the project** (replace the URL with the location of this repository if different):
+
+   ```bash
+   git clone https://example.com/bund.git
+   cd bund
+   ```
+
+3. **Create and activate a virtual environment**:
+
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+
+4. **Install the required Python package**:
+
+   ```bash
+   pip install requests
+   ```
+
+5. **Start the GUI**:
+
+   ```bash
+   python api_gui.py
+   ```
 
 ### Usage
-Run the GUI with:
 
-```bash
-python3 api_gui.py
-```
-
-Select a resource from the drop-down list, optionally enter an ID and query parameters (`key=value&other=123`). Press **Fetch** to request data from the API. The response will be shown as formatted JSON in the text area.
-
+The application includes a public API key so it works out of the box. Select a resource from the drop-down list, optionally enter an ID and query parameters (`key=value&other=123`). Press **Fetch** to request data from the API. The response will appear as formatted JSON in the text area.

--- a/api_gui.py
+++ b/api_gui.py
@@ -5,6 +5,8 @@ import json
 import urllib.parse
 
 BASE_URL = "https://search.dip.bundestag.de/api/v1"
+# Public API key provided by the Bundestag API documentation
+API_KEY = "OSOegLs.PR2lwJ1dwCeje9vTj7FPOt3hvpYKtwKkhw"
 
 class ApiGui(tk.Tk):
     def __init__(self):
@@ -17,8 +19,10 @@ class ApiGui(tk.Tk):
         api_frame = ttk.Frame(self)
         api_frame.pack(fill="x", padx=10, pady=5)
         ttk.Label(api_frame, text="API Key:").pack(side="left")
-        self.api_entry = ttk.Entry(api_frame, width=60, show="*")
+        self.api_entry = ttk.Entry(api_frame, width=60)
         self.api_entry.pack(side="left", padx=5)
+        # Pre-fill the entry with the public API key so the user can start immediately
+        self.api_entry.insert(0, API_KEY)
 
         main_frame = ttk.Frame(self)
         main_frame.pack(fill="x", padx=10, pady=5)
@@ -53,10 +57,7 @@ class ApiGui(tk.Tk):
         self.output.pack(fill="both", expand=True, padx=10, pady=10)
 
     def fetch(self):
-        api_key = self.api_entry.get().strip()
-        if not api_key:
-            messagebox.showwarning("API Key missing", "Please enter your API key.")
-            return
+        api_key = self.api_entry.get().strip() or API_KEY
         resource = self.resource_var.get()
         endpoint = f"/{resource}"
         item_id = self.id_entry.get().strip()


### PR DESCRIPTION
## Summary
- document installation steps using a virtual environment
- bundle a public API key with the GUI and pre-fill the key field

## Testing
- `python3 -m py_compile api_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_685d9efa1db8832293ef371ec4e4bd37