### PR TITLE
Add Gemini key input and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,34 @@
-# Run and deploy your AI Studio app
+# Bundestag DIP Explorer
 
-This contains everything you need to run your app locally.
+Dieses Projekt ist eine kleine Web-Oberfläche, um in den Dokumenten des Deutschen Bundestages zu suchen. Die Anwendung nutzt die öffentliche DIP-API und kann optional mit Gemini (Google AI) natürliche Sprachabfragen in Filter umwandeln.
 
-## Run Locally
+## Voraussetzungen
 
-**Prerequisites:**  Node.js
+* **Linux** (getestet unter Ubuntu)
+* **Node.js ab Version 18**
 
-1. Install dependencies:
-   `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
-   `npm run dev`
+## Schritt für Schritt
+
+1. Repository klonen (falls noch nicht geschehen):
+   ```bash
+   git clone <REPO_URL>
+   cd bund
+   ```
+2. Abhängigkeiten installieren:
+   ```bash
+   npm install
+   ```
+3. Entwicklungserver starten:
+   ```bash
+   npm run dev
+   ```
+   Danach erscheint eine lokale URL (z.B. `http://localhost:5173/`). Diese im Browser öffnen.
+
+4. Beim ersten Start befindet sich bereits ein öffentlicher API‑Key für die Bundestags‑API in [`constants.tsx`](./constants.tsx), sodass keine weitere Konfiguration nötig ist.
+
+5. Im Web‑Interface kann ein eigener Gemini‑API‑Key eingetragen werden. Einfach den Schlüssel im Feld "Gemini API Key" eingeben und **Enter** drücken oder auf **Speichern** klicken. Anschließend kann die intelligente Suche genutzt werden.
+
+## Hinweise
+
+* Für die Nutzung ohne Gemini kann das Feld leer bleiben. Die manuellen Filter funktionieren dann weiterhin.
+* Zum Erstellen einer Produktionsversion kann `npm run build` verwendet werden (benötigt eine vollständige Node‑Installation).


### PR DESCRIPTION
## Summary
- enable runtime configuration of Gemini API key
- add UI field to save Gemini API key
- document setup steps in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dabf6e34c8322a2242e0ae018c811